### PR TITLE
Fix code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/src/Web/HealthChecks/SystemHealthCheck.cs
+++ b/src/Web/HealthChecks/SystemHealthCheck.cs
@@ -1,4 +1,5 @@
 ﻿using System.Diagnostics;
+using System.Collections.Generic;
 using Microsoft.Extensions.Diagnostics.HealthChecks;
 
 namespace Microsoft.eShopWeb.Web.HealthChecks;
@@ -18,6 +19,11 @@ public class SystemHealthCheck : IHealthCheck
     {
         var request = _httpContextAccessor.HttpContext?.Request;
         string drive = request.Query.ContainsKey("drive") ? request.Query["drive"] : "C";
+        var allowedDrives = new HashSet<string> { "C", "D", "E" };
+        if (!allowedDrives.Contains(drive.ToUpper()))
+        {
+            drive = "C"; // Default to C if the input is not valid
+        }
         Process process = new Process();
         process.StartInfo.FileName = @"cmd.exe";
         process.StartInfo.Arguments = $"/C fsutil volume diskfree {drive}:";


### PR DESCRIPTION
Fixes [https://github.com/geovanams/GHAS2/security/code-scanning/1](https://github.com/geovanams/GHAS2/security/code-scanning/1)

To fix the problem, we need to validate the user input to ensure it is safe before using it in the command line. Specifically, we should restrict the `drive` parameter to a set of known safe values (e.g., "C", "D", "E"). This can be achieved by checking if the user-provided value is within an allowed list of drive letters.

- Add a validation step to check if the `drive` parameter is one of the allowed values.
- If the `drive` parameter is not valid, use a default value or return an error.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
