### PR TITLE
Fix code scanning alert no. 1: Uncontrolled command line

### DIFF
--- a/src/Web/HealthChecks/SystemHealthCheck.cs
+++ b/src/Web/HealthChecks/SystemHealthCheck.cs
@@ -18,15 +18,15 @@ public class SystemHealthCheck : IHealthCheck
         CancellationToken cancellationToken = default(CancellationToken))
     {
         var request = _httpContextAccessor.HttpContext?.Request;
-        string drive = request.Query.ContainsKey("drive") ? request.Query["drive"] : "C";
-        var allowedDrives = new HashSet<string> { "C", "D", "E" };
-        if (!allowedDrives.Contains(drive.ToUpper()))
+        string drive = request.Query.ContainsKey("drive") ? request.Query["drive"].ToUpper() : "C";
+        var driveMap = new Dictionary<string, string> { { "C", "C" }, { "D", "D" }, { "E", "E" } };
+        if (!driveMap.TryGetValue(drive, out string validDrive))
         {
-            drive = "C"; // Default to C if the input is not valid
+            validDrive = "C"; // Default to C if the input is not valid
         }
         Process process = new Process();
         process.StartInfo.FileName = @"cmd.exe";
-        process.StartInfo.Arguments = $"/C fsutil volume diskfree {drive}:";
+        process.StartInfo.Arguments = $"/C fsutil volume diskfree {validDrive}:";
         process.StartInfo.RedirectStandardOutput = true;
         process.StartInfo.UseShellExecute = false;
         process.Start();


### PR DESCRIPTION
Fixes [https://github.com/geovanams/GHAS2/security/code-scanning/1](https://github.com/geovanams/GHAS2/security/code-scanning/1)

To fix the problem, we should ensure that the `drive` variable is strictly limited to a set of predefined, hard-coded values. This can be achieved by using a dictionary or a similar structure to map user input to valid command arguments. This way, even if the user input is manipulated, it will not affect the command execution.

- Replace the current validation logic with a dictionary lookup to map user input to valid drive letters.
- Ensure that only valid, predefined drive letters are used in the command line argument.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
